### PR TITLE
Add utilities for movement vector scaling and target factor conversion

### DIFF
--- a/src/main/kotlin/cartState/translationLayer/TChangeFactors.kt
+++ b/src/main/kotlin/cartState/translationLayer/TChangeFactors.kt
@@ -1,0 +1,6 @@
+package nl.komenzie.cableCam.cartState.translationLayer
+
+data class TChangeFactors(
+    val changeT1Factor: Double,
+    val changeT2Factor: Double,
+)

--- a/src/main/kotlin/cartState/translationLayer/cartStateToTChangeFactors.kt
+++ b/src/main/kotlin/cartState/translationLayer/cartStateToTChangeFactors.kt
@@ -1,0 +1,30 @@
+package nl.komenzie.cableCam.cartState.translationLayer
+
+import nl.komenzie.cableCam.cartState.CartState
+import nl.komenzie.cableCam.geometry.Line
+import nl.komenzie.cableCam.geometry.Point
+import nl.komenzie.cableCam.position.calculateT1T2
+import kotlin.math.abs
+
+fun CartState.toTChangeFactors(targetPos: Point, aPos: Point): TChangeFactors {
+    val oPos = Point(0.0, 0.0)
+
+    val (currentT1, currentT2) = Point(
+        x = Line(oPos, position).length,
+        y = Line(aPos, position).length,
+    ).calculateT1T2()
+    val (targetT1, targetT2) = Point(
+        x = Line(oPos, targetPos).length,
+        y = Line(aPos, targetPos).length,
+    ).calculateT1T2()
+
+    val diffT1 = abs(targetT1 - currentT1)
+    val diffT2 = abs(targetT2 - currentT2)
+    val total = diffT1 + diffT2
+    if (total == 0.0) return TChangeFactors(0.5, 0.5)
+
+    return TChangeFactors(
+        changeT1Factor = diffT1 / total,
+        changeT2Factor = diffT2 / total,
+    )
+}

--- a/src/main/kotlin/constants/calcConstants.kt
+++ b/src/main/kotlin/constants/calcConstants.kt
@@ -1,0 +1,3 @@
+package nl.komenzie.cableCam.constants
+
+const val DT = 1

--- a/src/main/kotlin/movementVector/calculateMovementVector.kt
+++ b/src/main/kotlin/movementVector/calculateMovementVector.kt
@@ -1,6 +1,7 @@
 package nl.komenzie.cableCam.movementVector
 
 import nl.komenzie.cableCam.CableCamState
+import nl.komenzie.cableCam.constants.DT
 import nl.komenzie.cableCam.geometry.Line
 import nl.komenzie.cableCam.position.calculateCPos
 import kotlin.math.abs
@@ -21,6 +22,6 @@ fun CableCamState.calculateMovementVector(): MovementVector {
 
     return MovementVector(
         angle = Line(this.cPos, progressedCPos).angle,
-        speed = distance,   // m/s with s=1
+        speed = distance * DT,
     )
 }

--- a/src/main/kotlin/position/calculateT1T2.kt
+++ b/src/main/kotlin/position/calculateT1T2.kt
@@ -1,0 +1,9 @@
+package nl.komenzie.cableCam.position
+
+import nl.komenzie.cableCam.geometry.Point
+
+fun Point.calculateT1T2(): Pair<Double, Double> {
+    val t1 = x + 2 * y
+    val t2 = 3 * x + 2 * y
+    return t1 to t2
+}


### PR DESCRIPTION
### Description

This pull request introduces several utilities and changes to enhance movement calculations and facilitate conversion between `CartState` and `(T1, T2)` target factors:

- **`TChangeFactors` and `toTChangeFactors`**: A new `TChangeFactors` data class and a corresponding extension function to convert `CartState` into `(T1, T2)` change factors.
- **Movement Scaling**: Adjusted the `calculateMovementVector` function to scale speeds using the `DT` constant, improving accuracy in movement simulations.
- **`calculateT1T2` Extension**: Added a function in `Point` to compute `(T1, T2)` coordinates from `x` and `y` values.

### Checklist

- [ ] Unit tests added for new utilities and changes
- [ ] Documentation updated where necessary
- [ ] Regression tests executed